### PR TITLE
[CI][CLOUD] Increase timeout of no output for cloud test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,6 +471,7 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/orc8r/cloud/docker
             python3 build.py -g
+          no_output_timeout: 20m
       - run: sudo chown -R circleci $MAGMA_ROOT/*
       - run: git add .
       - run: git status


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[CI][CLOUD] Increase timeout of no output for cloud test

## Summary

Timing out due to no output for 10mins +. Increasing that time to unblock @hcgatewood 

## Test Plan
- Validate circleci yaml
`circleci config validate`

- Make sure it fixes the test
merge and let CI go 

## Additional Information

- [ ] This change is backwards-breaking

